### PR TITLE
Call JOSM over HTTP

### DIFF
--- a/webapp/app/templates/osm_id_way.html
+++ b/webapp/app/templates/osm_id_way.html
@@ -1,14 +1,14 @@
 {% if osm_id < 0 %}
     <a href="https://osm.org/relation/{{ osm_id*-1 }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/relation.png') }}">&nbsp;{{ osm_id*-1 }}</a>
     <small>
-        (<a href="https://localhost:8112/load_object?objects=r{{ osm_id*-1 }}&relation_members=true" title="{{ _("load in JOSM") }}" target="_blank">josm</a> 
+        (<a href="http://localhost:8111/load_object?objects=r{{ osm_id*-1 }}&relation_members=true" title="{{ _("load in JOSM") }}" target="_blank">josm</a> 
         | <a href="https://osm.org/edit?relation={{ osm_id*-1 }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>
         | <a href="http://ra.osmsurround.org/analyzeRelation?relationId={{ osm_id*-1 }}" title="{{ _("open in relation analyzer") }}" target="_blank">ra</a>)
     </small>
 {% else %}
     <a href="https://osm.org/way/{{ osm_id }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/way.png') }}">&nbsp;{{ osm_id }}</a>
     <small>
-        (<a href="https://localhost:8112/load_object?objects=w{{ osm_id }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
+        (<a href="http://localhost:8111/load_object?objects=w{{ osm_id }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
         | <a href="https://osm.org/edit?way={{ osm_id }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
     </small>
 {% endif %}


### PR DESCRIPTION
Https in JOSM is unreliable and has been dropped. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

w3c/webappsec-mixed-content@349501c
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.