### PR TITLE
Update neukoelln_fahrrad.csv

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -579,7 +579,7 @@ Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 4;A;N;N;Geh;2019;Wittmannsdorfer Straße 1-6;Anlehnbügel 2018 (SenUVK);52.471874;13.439374
 2;A;N;N;Geh;2019;Zwiestädter Straße 10;Anlehnbügel 2018 (SenUVK);52.47328;13.447894
 5;A;N;N;Geh;2019;Zwillingstraße 21;Anlehnbügel 2018 (SenUVK);52.467354;13.464315
-40;A;N;N;Geh;2019;Donaustraße 88;Sondermodelle;52.480045;13.440834
+40;A;N;N;Geh;2019;Donaustraße 88;Sondermodelle;52.47995;13.43991
 6;A;N;N;Geh;2019;Fontanestraße 8;Sondermodelle;52.480915;13.420555
 11;A;N;N;F;2019;Karl-Marx-Straße 13;PBL Karl-Marx-Straße;52.485615;13.426426
 2;A;N;N;F;2019;Karl-Marx-Straße 25;PBL Karl-Marx-Straße;52.484776;13.428273


### PR DESCRIPTION
Neue Lat/Lng für https://bikeparking.lorenz.lu/missingmap/Berlin%20Neuk%C3%B6lln#52.48006668528114/13.440644550137225/18/581

Die Formulierung "Sondermodelle" lässt mich stark vermuten, das diese Location  https://www.openstreetmap.org/way/741622413#map=19/52.47995/13.43991 gemeint ist. Das sind nämlich in der Tat besondere Fahrradständer: https://www.mapillary.com/app/user/tordans?lat=52.479976&lng=13.439386&z=17&focus=photo&pKey=7_el9JQFOx7tsFiIAp83sg