### PR TITLE
Uthmannstraße 15 / Update neukoelln_fahrrad.csv

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -559,7 +559,7 @@ Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 2;A;N;N;Geh;2019;Thomasstraße 67;Anlehnbügel 2018 (SenUVK);52.472054;13.431179
 6;A;N;N;F;2019;Treptower Straße 19;Anlehnbügel 2018 (SenUVK);52.480133;13.451043
 3;A;N;N;Geh;2019;Treptower Straße 68;Anlehnbügel 2018 (SenUVK);52.482758;13.454052
-3;A;N;N;F;2019;Uthmannstraße 15;Anlehnbügel 2018 (SenUVK);52.475414;13.441359
+3;A;N;N;F;2019;Uthmannstraße 15;Anlehnbügel 2018 (SenUVK);52.47524;13.44118
 3;A;N;N;Geh;2019;Warthestraße 12;Anlehnbügel 2018 (SenUVK);52.470123;13.426442
 3;A;N;N;Geh;2019;Warthestraße 62;Anlehnbügel 2018 (SenUVK);52.469803;13.426306
 3;A;N;N;Geh;2019;Wederstraße 87;Anlehnbügel 2018 (SenUVK);52.462044;13.435679


### PR DESCRIPTION
An der Straße ist kein Fahrradbügel. Ich vermute, er ist vor der Kita. Auf das Gelände kommt man aber nur zu den Öffnungszeiten – TBC. Mapillary Fotos gibt es noch nicht dort https://www.mapillary.com/app/?lat=52.47524000000149&lng=13.441179999998894&z=17.986393327658348&focus=map