### PR TITLE
Thomasstraße  / Update neukoelln_fahrrad.csv

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -552,8 +552,8 @@ Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 3;A;N;N;Geh;2019;Sülzhayner Straße 28;Anlehnbügel 2018 (SenUVK);52.487255;13.44602
 4;A;N;N;Geh;2019;Sülzhayner Straße 8;Anlehnbügel 2018 (SenUVK);52.48775;13.44581
 6;A;N;N;Geh;2019;Theodor Loos Ring 14 (Spielplätze);Anlehnbügel 2018 (SenUVK);52.42213;13.477458
-2;A;N;N;Geh;2019;Thomasstraße 15;Anlehnbügel 2018 (SenUVK);52.473454;13.438875
-3;A;N;N;Geh;2019;Thomasstraße 21;Anlehnbügel 2018 (SenUVK);52.47327;13.4382925
+2;A;N;N;Geh;2019;Thomasstraße 15;Anlehnbügel 2018 (SenUVK);52,4736675;13,4387278
+3;A;N;N;Geh;2019;Thomasstraße 21;Anlehnbügel 2018 (SenUVK);52,4734553;13,4378660
 3;A;N;N;Geh;2019;Thomasstraße 23;Anlehnbügel 2018 (SenUVK);52.4730788;13.4378412
 2;A;N;N;Geh;2019;Thomasstraße 55;Anlehnbügel 2018 (SenUVK);52.47232;13.433288
 2;A;N;N;Geh;2019;Thomasstraße 67;Anlehnbügel 2018 (SenUVK);52.472054;13.431179


### PR DESCRIPTION
Die beiden Bügel in der Thomasstraße wurden zwar inzwischen von der App richtig gematched mit den Bügeln auf der gegenüberliegen Straßenseite, trotzdem ist diese GeoLoc etwas präziser.