### PR TITLE
Retry Maproulette GeoJSON

### DIFF
--- a/webapp/app/geojson/routes.py
+++ b/webapp/app/geojson/routes.py
@@ -141,6 +141,9 @@ def geojson_parking_area(city):
     return rental_data.geojson
 
 
+# lessContent is False for /geojson/existing/<city>
+# lessContent is False for /geojson/missing/<city>?bbox=…
+# lessContent is True for /geojson/missing/<city> (without bbox-Param)
 def render_geojson_nodes_external(result, city, existing=False, lessContent=False):
     features = []
     for row in result:
@@ -155,18 +158,18 @@ def render_geojson_nodes_external(result, city, existing=False, lessContent=Fals
             prop['missing'] = 'no'
         geom = {'type': 'Point', 'coordinates': [row['lon'], row['lat']]}
         entry = {'type': 'Feature', 'properties': prop, 'geometry': geom}
-#        if lessContent:
-#            # Add id for maproulette
-#            if prop['gml_id']:
-#                entry['@id'] = prop['gml_id']
-#            elif prop['stellplatz_nr']:
-#                entry['@id'] = prop['stellplatz_nr']
-#            elif prop['uuid']:
-#                entry['@id'] = prop['uuid']
-#            elif prop['ident']:
-#                entry['@id'] = prop['ident']
-#            elif prop['id']:
-#                entry['@id'] = prop['id']
+        if lessContent:
+            # Add id for maproulette
+            if prop['uuid']:
+                entry['@id'] = prop['uuid']
+            if prop['gml_id']:
+                entry['@externalId'] = prop['gml_id']
+            elif prop['stellplatz_nr']:
+                entry['@externalId'] = prop['stellplatz_nr']
+            elif prop['ident']:
+                entry['@externalId'] = prop['ident']
+            elif prop['id']:
+                entry['@externalId'] = prop['id']
 
         features.append(entry)
 


### PR DESCRIPTION
This might solve the Maproulette Problem from https://github.com/britiger/bikeparkingberlin/issues/24#issuecomment-543953182.
I followed nrotstan's recommendations from https://github.com/osmlab/maproulette3/issues/952#issuecomment-583753724 and added the uuid as geojson-id on every entry. Our identifiers are moved to externalId – which we might need to remove as well, should they be to similar to OSM IDs.