### PR TITLE
Bügel aus dem Datensatz neukoelln_fahrrad.csv, die ich nicht finden konnte

### DIFF
--- a/database/non_existing_data/neukoelln_fahrrad.csv
+++ b/database/non_existing_data/neukoelln_fahrrad.csv
@@ -1,0 +1,5 @@
+"id";"osm user";"comment";"mapillary pKey"
+"561";"tordans";"Auf der Straße gibt es keine Fahrradbügel. Die nächsten Bügel sind private Bügel direkt vor dem Kita-Gebäude in Hausnummer 17.";"bDU3eQvYrTSzvLUPxwsuzw"
+"404";"tordans";"An der Straße ist eine Baustelle. Die übrigen Bügel in der Straße konnte ich finden, aber vor dem Haus 37 oder 37B sind die Bügel vermutlich aufgrund der Baustelle abgebaut oder nie aufgebaut worden.";"aAqv6YEEQf-RI-5sFJyZCQ"
+"391";"tordans";"Auf der Straße und auch in der Nähe am Gehweg konnte ich keine Bügel finden.";""
+"484";"tordans";"Auf der Straße und auch in der Nähe am Gehweg konnte ich keine Bügel finden.";""


### PR DESCRIPTION
Angaben zu vier Bügeln, die ich nicht finden konnte.

Ich folge mit dieser Datei der Idee von https://github.com/britiger/bikeparkingberlin/issues/46.

Auch unabhängig davon, ob die Idee von https://github.com/britiger/bikeparkingberlin/issues/46 weiter verfolgt wird, ist das IMO eine ganz gute Art, das Feedback zu den Bügeln zu sammeln.