### PR TITLE
Update neukoelln_fahrrad.csv / Kita Wildenbruchstr

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -349,7 +349,7 @@ Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 1;A;N;N;Geh;2018;Wildenbruchstraße 18;Anlehnbügel 2018 (SenUVK);52.48562;13.445548
 1;A;N;N;Geh;2018;Wildenbruchstraße 20;Anlehnbügel 2018 (SenUVK);52.48562;13.445548
 2;A;N;N;Geh;2018;Wildenbruchstraße 23;Anlehnbügel 2018 (SenUVK);52.486412;13.446717
-6;A;N;N;Geh;2018;Wildenbruchstraße 25 (Kita);Anlehnbügel 2018 (SenUVK);52.48665;13.447763
+6;A;N;N;Geh;2018;Wildenbruchstraße 25 (Kita);Anlehnbügel 2018 (SenUVK);52.48680;13.44709
 2;A;N;N;Geh;2018;Wildenbruchstraße 66A;Anlehnbügel 2018 (SenUVK);52.486828;13.44663
 2;A;N;N;Geh;2018;Wildenbruchstraße 8;Anlehnbügel 2018 (SenUVK);52.48319;13.442282
 3;A;N;N;Geh;2018;Wildenbruchstraße 82/83;Anlehnbügel 2018 (SenUVK);52.48365;13.4425335


### PR DESCRIPTION
Die Kita-Fläche ist recht groß, daher sind die Geokoordinaten etwas off. Die Bügel sind eingetragen unter https://www.openstreetmap.org/node/7212523321.