### PR TITLE
Update neukoelln_fahrrad.csv / Schule Elbestr. 11

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -29,7 +29,7 @@ Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 2;A;N;N;Geh;2018;Donaustraße 81;Anlehnbügel 2018 (SenUVK);52.478462;13.442514
 3;A;N;N;F;2018;Elbestraße 1;Anlehnbügel 2018 (SenUVK);52.48289;13.438486
 7;A;N;N;F;2018;Elbestraße 1 (Mitttelstreifen);Anlehnbügel 2018 (SenUVK);52.48289;13.438486
-5;A;N;N;F;2018;Elbestraße 11;Anlehnbügel 2018 (SenUVK);52.484074;13.441289
+5;A;N;N;F;2018;Elbestraße 11;Anlehnbügel 2018 (SenUVK);52.48433;13.44033
 2;A;N;N;Geh;2018;Elbestraße 17/18;Anlehnbügel 2018 (SenUVK);52.485237;13.44162
 3;A;N;N;F;2018;Elbestraße 19;Anlehnbügel 2018 (SenUVK);52.485584;13.442041
 2;A;N;N;Geh;2018;Elbestraße 24;Anlehnbügel 2018 (SenUVK);52.48539;13.441275


### PR DESCRIPTION
Die städtischen Daten sprechen von Bügeln auf der Fahrbahn, das müssten dann https://www.openstreetmap.org/way/744102483 sein.