### PR TITLE
Update neukoelln_fahrrad / Schule Karlsgartenstr

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -128,7 +128,7 @@ Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 2;A;N;N;Geh;2018;Karlsgartenstraße 6;Anlehnbügel 2018 (SenUVK);52.48217;13.422211
 3;A;N;N;Geh;2018;Karlsgartenstraße 6;Anlehnbügel 2018 (SenUVK);52.48217;13.422211
 3;A;N;N;Geh;2018;Karlsgartenstraße 6;Anlehnbügel 2018 (SenUVK);52.48217;13.422211
-3;A;N;N;Geh;2018;Karlsgartenstraße 7;Anlehnbügel 2018 (SenUVK);52.482685;13.421485
+3;A;N;N;Geh;2018;Karlsgartenstraße 7;Anlehnbügel 2018 (SenUVK);52.48197;13.42093
 1;A;N;N;Geh;2018;Kiehlufer 49;Anlehnbügel 2018 (SenUVK);52.4855;13.4442425
 2;A;N;N;Geh;2018;Kiehlufer 51/53;Anlehnbügel 2018 (SenUVK);52.485413;13.444411
 3;A;N;N;Geh;2018;Kiehlufer 65;Anlehnbügel 2018 (SenUVK);52.4845;13.446196


### PR DESCRIPTION
Die städtischen Daten sprechen von 3 Bügeln auf dem Gehweg, das dürften dann https://www.openstreetmap.org/node/6079542824 sein. An dem Gehweg sind aber inzwischen viele weitere Bügel, die auch passen würden.