### PR TITLE
Update parking_non_existing.csv / Quote for Header

### DIFF
--- a/database/external_data/parking_non_existing.csv
+++ b/database/external_data/parking_non_existing.csv
@@ -1,4 +1,4 @@
-suffix;obj_id;osm_user;feedback
+suffix;"obj_id";"osm_user";"feedback"
 berlin_neukoelln;"561";"tordans";"Auf der Straße gibt es keine Fahrradbügel. Die nächsten Bügel sind private Bügel direkt vor dem Kita-Gebäude in Hausnummer 17. Mapilary: bDU3eQvYrTSzvLUPxwsuzw"
 berlin_neukoelln;"404";"tordans";"An der Straße ist eine Baustelle. Die übrigen Bügel in der Straße konnte ich finden, aber vor dem Haus 37 oder 37B sind die Bügel vermutlich aufgrund der Baustelle abgebaut oder nie aufgebaut worden. Mapillary: aAqv6YEEQf-RI-5sFJyZCQ"
 berlin_neukoelln;"391";"tordans";"Auf der Straße und auch in der Nähe am Gehweg konnte ich keine Bügel finden."


### PR DESCRIPTION
Github complains about the csv format and I wonder if it's because the header-line does not use quote …
> We can make this file beautiful and searchable if this error is corrected: Illegal quoting in line 2.
(https://help.github.com/en/github/managing-files-in-a-repository/rendering-csv-and-tsv-data)