### PR TITLE
Update neukoelln_fahrrad.csv / Delbrückstraße 17

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -394,7 +394,7 @@ id;Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 393;3;A;N;N;Geh;2019;Bauführerweg 20;Anlehnbügel 2018 (SenUVK);52.431454;13.445991
 394;2;A;N;N;Geh;2019;Bendastraße 21;Anlehnbügel 2018 (SenUVK);52.466476;13.436726
 395;2;A;N;N;Geh;2019;Bendastraße 6;Anlehnbügel 2018 (SenUVK);52.4648;13.436837
-396;5;A;N;N;Geh;2019;Bendastraße17;Anlehnbügel 2018 (SenUVK);52.464214;13.437429
+396;5;A;N;N;Geh;2019;Bendastraße 17;Anlehnbügel 2018 (SenUVK);52.46530;13.43708
 397;2;A;N;N;Geh;2019;Berthelsdorfer Straße 10;Anlehnbügel 2018 (SenUVK);52.478607;13.440704
 398;3;A;N;N;Geh;2019;Biebricher Straße 1A;Anlehnbügel 2018 (SenUVK);52.481766;13.425408
 399;2;A;N;N;Geh;2019;Boddinstraße 1;Anlehnbügel 2018 (SenUVK);52.481075;13.434288


### PR DESCRIPTION
Geocoding probably did not work probably cause the address was missing a space. This looks like the more correct lat/lng https://www.openstreetmap.org/node/2435065085#map=19/52.46530/13.43708. However, there are no bike stands right on that street https://www.mapillary.com/app/user/tordans?pKey=cDsL7mZ19LsWdiQRcBz3LQ&focus=photo&lat=52.465597525492186&lng=13.436810417093366&z=17&x=0.5185684611135137&y=0.38587485943041216&zoom=0. There might be some around the corner, though, so still need to double check that.