### PR TITLE
Update parking_non_existing.csv / Karl-Marx-Straße, Bügel 123

### DIFF
--- a/database/external_data/parking_non_existing.csv
+++ b/database/external_data/parking_non_existing.csv
@@ -1,4 +1,5 @@
 suffix;obj_id;osm_user;feedback
+berlin_neukoelln;"123";"tordans";"Die gesamte Bürgersteigfläche ist durch die Baustelle nur eingeschränkt nutzbar; es sind keine Bügel auf dem Gehweg zu sehen. Wohl aber gegenüber Ecke Neckarstraße."
 berlin_neukoelln;"561";"tordans";"Auf der Straße gibt es keine Fahrradbügel. Die nächsten Bügel sind private Bügel direkt vor dem Kita-Gebäude in Hausnummer 17. Mapilary: bDU3eQvYrTSzvLUPxwsuzw"
 berlin_neukoelln;"404";"tordans";"An der Straße ist eine Baustelle. Die übrigen Bügel in der Straße konnte ich finden, aber vor dem Haus 37 oder 37B sind die Bügel vermutlich aufgrund der Baustelle abgebaut oder nie aufgebaut worden. Mapillary: aAqv6YEEQf-RI-5sFJyZCQ"
 berlin_neukoelln;"391";"tordans";"Auf der Straße und auch in der Nähe am Gehweg konnte ich keine Bügel finden."


### PR DESCRIPTION
Baustelle Karl-Marx-Straße, Bügel nicht zu finden. Leider helfen diese Fotos als "Beweis" nicht wirklich https://www.mapillary.com/app/user/tordans?pKey=Ep-P9s_FcTl93-QsNyM_rQ&focus=photo&lat=52.48046736285506&lng=13.435662653197621&z=17&tab=uploads.