### PR TITLE
Add osm link to shorthands

### DIFF
--- a/webapp/app/templates/node_popup_external.html
+++ b/webapp/app/templates/node_popup_external.html
@@ -52,5 +52,6 @@
     <small>
         (<a href="http://localhost:8111/load_and_zoom?top={{ node['lat'] }}&bottom={{ node['lat'] }}&left={{ node['lon'] }}&right={{ node['lon'] }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
         | <a href="https://www.openstreetmap.org/edit#map=19/{{ node['lat'] }}/{{ node['lon'] }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
+        | <a href="https://www.openstreetmap.org/node/{{ node['int_osm_id'] }}" title="{{ _("show on openstreetmap.org") }}" target="_blank">OSM</a>)
     </small>
 {% endif %}

--- a/webapp/app/templates/node_popup_external.html
+++ b/webapp/app/templates/node_popup_external.html
@@ -51,6 +51,6 @@
     {{ _('Open Editor') }}:
     <small>
         (<a href="http://localhost:8111/load_and_zoom?top={{ node['lat'] }}&bottom={{ node['lat'] }}&left={{ node['lon'] }}&right={{ node['lon'] }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
-        | <a href="https://osm.org/edit#map=19/{{ node['lat'] }}/{{ node['lon'] }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
+        | <a href="https://www.openstreetmap.org/edit#map=19/{{ node['lat'] }}/{{ node['lon'] }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
     </small>
 {% endif %}

--- a/webapp/app/templates/node_popup_rental.html
+++ b/webapp/app/templates/node_popup_rental.html
@@ -46,6 +46,6 @@
     {{ _('Open Editor') }}:
     <small>
         (<a href="http://localhost:8111/load_and_zoom?top={{ node['lat'] }}&bottom={{ node['lat'] }}&left={{ node['lon'] }}&right={{ node['lon'] }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
-        | <a href="https://osm.org/edit#map=19/{{ node['lat'] }}/{{ node['lon'] }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
+        | <a href="https://www.openstreetmap.org/edit#map=19/{{ node['lat'] }}/{{ node['lon'] }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
     </small>
 {% endif %}

--- a/webapp/app/templates/node_popup_rental.html
+++ b/webapp/app/templates/node_popup_rental.html
@@ -47,5 +47,6 @@
     <small>
         (<a href="http://localhost:8111/load_and_zoom?top={{ node['lat'] }}&bottom={{ node['lat'] }}&left={{ node['lon'] }}&right={{ node['lon'] }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
         | <a href="https://www.openstreetmap.org/edit#map=19/{{ node['lat'] }}/{{ node['lon'] }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
+        | <a href="https://www.openstreetmap.org/node/{{ node['int_osm_id'] }}" title="{{ _("show on openstreetmap.org") }}" target="_blank">OSM</a>)
     </small>
 {% endif %}

--- a/webapp/app/templates/osm_id_node.html
+++ b/webapp/app/templates/osm_id_node.html
@@ -5,5 +5,6 @@
     <small>
         (<a href="http://localhost:8111/load_object?objects=n{{ osm_id }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
         | <a href="https://www.openstreetmap.org/edit?node={{ osm_id }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
+        | <a href="https://www.openstreetmap.org/node/{{ osm_id }}" title="{{ _("show on openstreetmap.org") }}" target="_blank">OSM</a>)
     </small>
 {% endif %}

--- a/webapp/app/templates/osm_id_node.html
+++ b/webapp/app/templates/osm_id_node.html
@@ -1,9 +1,9 @@
 {% if typ == 'area' %}
     {% with osm_id=osm_id %}{% include "osm_id_way.html" %}{% endwith %}
 {% else %}
-    <a href="https://osm.org/node/{{ osm_id }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/node.png') }}">&nbsp;{{ osm_id }}</a>
+    <a href="https://www.openstreetmap.org/node/{{ osm_id }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/node.png') }}">&nbsp;{{ osm_id }}</a>
     <small>
         (<a href="http://localhost:8111/load_object?objects=n{{ osm_id }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
-        | <a href="https://osm.org/edit?node={{ osm_id }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
+        | <a href="https://www.openstreetmap.org/edit?node={{ osm_id }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
     </small>
 {% endif %}

--- a/webapp/app/templates/osm_id_way.html
+++ b/webapp/app/templates/osm_id_way.html
@@ -4,11 +4,13 @@
         (<a href="http://localhost:8111/load_object?objects=r{{ osm_id*-1 }}&relation_members=true" title="{{ _("load in JOSM") }}" target="_blank">josm</a> 
         | <a href="https://www.openstreetmap.org/edit?relation={{ osm_id*-1 }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>
         | <a href="http://ra.osmsurround.org/analyzeRelation?relationId={{ osm_id*-1 }}" title="{{ _("open in relation analyzer") }}" target="_blank">ra</a>)
+        | <a href="https://www.openstreetmap.org/relation/{{ osm_id*-1 }}" title="{{ _("show on openstreetmap.org") }}" target="_blank">OSM</a>)
     </small>
 {% else %}
     <a href="https://www.openstreetmap.org/way/{{ osm_id }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/way.png') }}">&nbsp;{{ osm_id }}</a>
     <small>
         (<a href="http://localhost:8111/load_object?objects=w{{ osm_id }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
         | <a href="https://www.openstreetmap.org/edit?way={{ osm_id }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
+        | <a href="https://www.openstreetmap.org/node/{{ osm_id }}" title="{{ _("show on openstreetmap.org") }}" target="_blank">OSM</a>)
     </small>
 {% endif %}

--- a/webapp/app/templates/osm_id_way.html
+++ b/webapp/app/templates/osm_id_way.html
@@ -1,14 +1,14 @@
 {% if osm_id < 0 %}
-    <a href="https://osm.org/relation/{{ osm_id*-1 }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/relation.png') }}">&nbsp;{{ osm_id*-1 }}</a>
+    <a href="https://www.openstreetmap.org/relation/{{ osm_id*-1 }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/relation.png') }}">&nbsp;{{ osm_id*-1 }}</a>
     <small>
         (<a href="http://localhost:8111/load_object?objects=r{{ osm_id*-1 }}&relation_members=true" title="{{ _("load in JOSM") }}" target="_blank">josm</a> 
-        | <a href="https://osm.org/edit?relation={{ osm_id*-1 }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>
+        | <a href="https://www.openstreetmap.org/edit?relation={{ osm_id*-1 }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>
         | <a href="http://ra.osmsurround.org/analyzeRelation?relationId={{ osm_id*-1 }}" title="{{ _("open in relation analyzer") }}" target="_blank">ra</a>)
     </small>
 {% else %}
-    <a href="https://osm.org/way/{{ osm_id }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/way.png') }}">&nbsp;{{ osm_id }}</a>
+    <a href="https://www.openstreetmap.org/way/{{ osm_id }}" class="osm_id_line" target="_blank"><img src="{{ url_for('static', filename='img/way.png') }}">&nbsp;{{ osm_id }}</a>
     <small>
         (<a href="http://localhost:8111/load_object?objects=w{{ osm_id }}" title="{{ _("load in JOSM") }}" target="_blank">josm</a>
-        | <a href="https://osm.org/edit?way={{ osm_id }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
+        | <a href="https://www.openstreetmap.org/edit?way={{ osm_id }}&comment=%23bikeparking" title="{{ _("edit with iD Editor") }}" target="_blank">iD</a>)
     </small>
 {% endif %}

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -189,13 +189,19 @@ msgstr "Editor öffnen"
 
 #: app/templates/node_popup_external.html:53
 #: app/templates/node_popup_rental.html:48 app/templates/osm_id_node.html:6
-#: app/templates/osm_id_way.html:4 app/templates/osm_id_way.html:11
+#: app/templates/osm_id_way.html:4 app/templates/osm_id_way.html:12
 msgid "load in JOSM"
 msgstr "In JOSM laden"
 
-#: app/templates/node_popup_external.html:54
+#: app/templates/node_popup_external.html:55
 #: app/templates/node_popup_rental.html:49 app/templates/osm_id_node.html:7
-#: app/templates/osm_id_way.html:5 app/templates/osm_id_way.html:12
+#: app/templates/osm_id_way.html:7 app/templates/osm_id_way.html:14
+msgid "show on openstreetmap.org"
+msgstr "Auf openstreetmap.org anzeigen"
+
+#: app/templates/node_popup_external.html:54
+#: app/templates/node_popup_rental.html:50 app/templates/osm_id_node.html:8
+#: app/templates/osm_id_way.html:5 app/templates/osm_id_way.html:13
 msgid "edit with iD Editor"
 msgstr "Mit iD Editor bearbeiten"
 


### PR DESCRIPTION
I found myself looking for a way to open osm.org from the node popup. This would add such a link via the quicklink feature.

This PR includes the changes from https://github.com/britiger/bikeparkingberlin/pull/60 to avoid merge conflicts, so should this get merges the other one (https://github.com/britiger/bikeparkingberlin/pull/60) can be discarded.

Todo: I edited the translation file manually, which is always a risk and might have erros.