### PR TITLE
Update neukoelln_fahrrad.csv / Hänselstraße präzisiert

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -458,7 +458,7 @@ id;Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 457;2;A;N;N;Geh;2019;Hannemannstraße 24;Anlehnbügel 2018 (SenUVK);52.4553;13.44637
 458;3;A;N;N;Geh;2019;Hannemannstraße 32;Anlehnbügel 2018 (SenUVK);52.455143;13.445071
 459;2;A;N;N;Geh;2019;Hannemannstraße 43;Anlehnbügel 2018 (SenUVK);52.454624;13.443023
-460;2;A;N;N;Geh;2019;Hänselstraße 6;Anlehnbügel 2018 (SenUVK);52.46662;13.473873
+460;2;A;N;N;Geh;2019;Hänselstraße 6;Anlehnbügel 2018 (SenUVK);52.4670637;13.4727157
 461;3;A;N;N;Geh;2019;Heidelberger Straße 35;Anlehnbügel 2018 (SenUVK);52.485893;13.452776
 462;2;A;N;N;Geh;2019;Hermannstraße 144;Anlehnbügel 2018 (SenUVK);52.46385;13.4337
 463;3;A;N;J;Geh;2019;Hermannstraße 180;Anlehnbügel 2018 (SenUVK);52.47273;13.428795


### PR DESCRIPTION
Da hier vom Gehweg gesprochen wird, muss es https://www.openstreetmap.org/node/7518811253 sein. Direkt daneben sind auch Bügel auf der Straße, aber vielleicht kamen die später(?).