### PR TITLE
Bike stands exist now / Altenbraker Straße

### DIFF
--- a/database/external_data/parking_non_existing.csv
+++ b/database/external_data/parking_non_existing.csv
@@ -5,7 +5,6 @@ berlin_neukoelln;"279";"tordans";"In der Umgebung konnte ich keine Bügel finden
 berlin_neukoelln;"123";"tordans";"Die gesamte Bürgersteigfläche ist durch die Baustelle nur eingeschränkt nutzbar; es sind keine Bügel auf dem Gehweg zu sehen. Wohl aber gegenüber Ecke Neckarstraße."
 berlin_neukoelln;"561";"tordans";"Auf der Straße gibt es keine Fahrradbügel. Die nächsten Bügel sind private Bügel direkt vor dem Kita-Gebäude in Hausnummer 17. Mapilary: bDU3eQvYrTSzvLUPxwsuzw"
 berlin_neukoelln;"404";"tordans";"An der Straße ist eine Baustelle. Die übrigen Bügel in der Straße konnte ich finden, aber vor dem Haus 37 oder 37B sind die Bügel vermutlich aufgrund der Baustelle abgebaut oder nie aufgebaut worden. Mapillary: aAqv6YEEQf-RI-5sFJyZCQ"
-berlin_neukoelln;"391";"tordans";"Auf der Straße und auch in der Nähe am Gehweg konnte ich keine Bügel finden."
 berlin_neukoelln;"452";"tordans";"Vor dem Stadtbad sind keine Bügel auf der Straße angebracht. Die Bügel ggü. dem Prachtwerk passen nicht zur angegebenen Adresse. Mapillary: https://www.mapillary.com/app/user/tordans?pKey=PncF4HRz7UvzW8m1cFACDw&focus=photo"
 berlin_neukoelln;"478";"tordans";"Rund um den U-Bahn-Ausgang sind keine Bügel zu finden. Mapillary: https://www.mapillary.com/app/user/tordans?pKey=jniQDVM3yE9n9aBFVoddGg&focus=photo"
 berlin;"s_Fahrradstaender.9023";"tordans";"An diesem Ort ist eine Mietfahrrad-Station, keine öffentlichen Fahrradständer"


### PR DESCRIPTION
Maybe the Bezirk is looking at our app? One blue marker after the other seems to be wrong since the bike stands appear – with some delay :-).

Those stands are now at 
- https://www.openstreetmap.org/changeset/87416307#map=19/52.46821/13.43299&layers=N
- https://www.mapillary.com/app/?pKey=yjc7usEQAltS8kTRQZl8RJ&focus=photo&lat=52.46810534225448&lng=13.43311904230124&z=17 and https://www.mapillary.com/app/?pKey=2EFzX0EjjDXRhDAcqEbgfb&focus=photo&lat=52.46810555641673&lng=13.433101117135841&z=17