### PR TITLE
Fahrradständer 561 wurde in 2020 "nachgeliefert"

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -559,7 +559,7 @@ id;Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 558;2;A;N;N;Geh;2019;Thomasstraße 67;Anlehnbügel 2018 (SenUVK);52.472054;13.431179
 559;6;A;N;N;F;2019;Treptower Straße 19;Anlehnbügel 2018 (SenUVK);52.480133;13.451043
 560;3;A;N;N;Geh;2019;Treptower Straße 68;Anlehnbügel 2018 (SenUVK);52.482758;13.454052
-561;3;A;N;N;F;2019;Uthmannstraße 15;Anlehnbügel 2018 (SenUVK);52.475414;13.441359
+561;3;A;N;N;F;2019;Uthmannstraße 15;Anlehnbügel 2018 (SenUVK);52.4753930,13.4406447
 562;3;A;N;N;Geh;2019;Warthestraße 12;Anlehnbügel 2018 (SenUVK);52.470123;13.426442
 563;3;A;N;N;Geh;2019;Warthestraße 62;Anlehnbügel 2018 (SenUVK);52.469803;13.426306
 564;3;A;N;N;Geh;2019;Wederstraße 87;Anlehnbügel 2018 (SenUVK);52.462044;13.435679

--- a/database/external_data/parking_non_existing.csv
+++ b/database/external_data/parking_non_existing.csv
@@ -3,7 +3,6 @@ berlin_neukoelln;"250";"tordans";"In der Umgebung konnte ich keine Bügel finden
 berlin_neukoelln;"251";"tordans";"In der Umgebung konnte ich keine Bügel finden. Mapillary: https://www.mapillary.com/app/user/tordans?pKey=156LpywkFQ_IBgbgXQqjwg"
 berlin_neukoelln;"279";"tordans";"In der Umgebung konnte ich keine Bügel finden. Die nächsten Fahrradständer sind an der Ecke Oderstraße. Mapillary: https://www.mapillary.com/app/user/tordans?pKey=Sf6tYtVI2BRImXqrNBr_fA"
 berlin_neukoelln;"123";"tordans";"Die gesamte Bürgersteigfläche ist durch die Baustelle nur eingeschränkt nutzbar; es sind keine Bügel auf dem Gehweg zu sehen. Wohl aber gegenüber Ecke Neckarstraße."
-berlin_neukoelln;"561";"tordans";"Auf der Straße gibt es keine Fahrradbügel. Die nächsten Bügel sind private Bügel direkt vor dem Kita-Gebäude in Hausnummer 17. Mapilary: bDU3eQvYrTSzvLUPxwsuzw"
 berlin_neukoelln;"404";"tordans";"An der Straße ist eine Baustelle. Die übrigen Bügel in der Straße konnte ich finden, aber vor dem Haus 37 oder 37B sind die Bügel vermutlich aufgrund der Baustelle abgebaut oder nie aufgebaut worden. Mapillary: aAqv6YEEQf-RI-5sFJyZCQ"
 berlin_neukoelln;"391";"tordans";"Auf der Straße und auch in der Nähe am Gehweg konnte ich keine Bügel finden."
 berlin_neukoelln;"452";"tordans";"Vor dem Stadtbad sind keine Bügel auf der Straße angebracht. Die Bügel ggü. dem Prachtwerk passen nicht zur angegebenen Adresse. Mapillary: https://www.mapillary.com/app/user/tordans?pKey=PncF4HRz7UvzW8m1cFACDw&focus=photo"


### PR DESCRIPTION
- [x] Siehe https://www.openstreetmap.org/way/824532572
Der Bügel steht zwar jetzt nicht vor Hausnummer 15, wie in den Daten angegeben, sondern an der 21; aber er passt inhaltlich zu den Angaben des Bezirks-Datensatzen. Mapillary: https://www.mapillary.com/app/?pKey=YUSgQYdblxN1yYTTelXqQQ. In Hausnr 17 ist eine Kita; ich vermute für diese sind die Bügel gedacht.

- [x] Der Bügel mappt in den Daten noch fälschlich auf https://www.openstreetmap.org/node/7226654919; ich positioniere ihn um.