### PR TITLE
Update neukoelln_fahrrad.csv  / ID 350, Wildenbruchstraße verschoben

### DIFF
--- a/database/external_data/neukoelln_fahrrad.csv
+++ b/database/external_data/neukoelln_fahrrad.csv
@@ -348,7 +348,7 @@ id;Anzahl;Art;Überberdacht;ÖPNV;Ort;Jahr;Adresse;Projekt;lat;lon
 347;2;A;N;N;Geh;2018;Wildenbruchstraße 12/13;Anlehnbügel 2018 (SenUVK);52.483646;13.4429655
 348;1;A;N;N;Geh;2018;Wildenbruchstraße 18;Anlehnbügel 2018 (SenUVK);52.48562;13.445548
 349;1;A;N;N;Geh;2018;Wildenbruchstraße 20;Anlehnbügel 2018 (SenUVK);52.48562;13.445548
-350;2;A;N;N;Geh;2018;Wildenbruchstraße 23;Anlehnbügel 2018 (SenUVK);52.486412;13.446717
+350;2;A;N;N;Geh;2018;Wildenbruchstraße 23;Anlehnbügel 2018 (SenUVK);52.4868021;13.4470995
 351;6;A;N;N;Geh;2018;Wildenbruchstraße 25 (Kita);Anlehnbügel 2018 (SenUVK);52.48680;13.44709
 352;2;A;N;N;Geh;2018;Wildenbruchstraße 66A;Anlehnbügel 2018 (SenUVK);52.486828;13.44663
 353;2;A;N;N;Geh;2018;Wildenbruchstraße 8;Anlehnbügel 2018 (SenUVK);52.48319;13.442282


### PR DESCRIPTION
Direkt an der Ecke Hausnummer 23 gibt es keine Ständer. 
- https://www.mapillary.com/app/?pKey=qnirE1N8FSsr2Qe10B7Law&focus=photo&lat=52.4863524&lng=13.446406899972223&z=17&x=0.5285638761905924&y=0.5092306011556772&zoom=0
- https://www.mapillary.com/app/?pKey=ZUuV4GBleo2hkLbM4Iz1wQ&focus=photo&lat=52.48669613623206&lng=13.445663973696561&z=17&x=0.4891675942968628&y=0.5634569529902107&zoom=0
- https://www.mapillary.com/app/?pKey=b8fx8ZKfzKgL9GX-n9wpLw&focus=photo&lat=52.486281772193024&lng=13.446833118808854&z=17

Aber ein paar Meter weiter vor der Kita wurden viele platziert. Ich habe daher die Geokoordinaten verschoben.
- https://www.mapillary.com/app/?pKey=A2BH29YsH2In8GgK2gidLQ&focus=photo&lat=52.48677289304473&lng=13.447005910362781&z=17