### PR TITLE
Improve wording of missing export link

### DIFF
--- a/webapp/app/templates/missing_map.html
+++ b/webapp/app/templates/missing_map.html
@@ -111,7 +111,8 @@
                                 <a href="?is_cluster=true">{{ _('Show Clustered') }}</a> &#x2022;
                             {% endif %}
                         {% endif %}
-                        <a href="/geojson/missing/{{ city }}{% if is_cluster %}?is_cluster=true{% endif %}" target="_blank">{{ _('Export Missing') }} (GeoJSON)</a>
+                        <!-- Wenn https://github.com/britiger/bikeparkingberlin/issues/45 gemacht ist, kann das vermutlich wieder auf "Export Fehlende" reduziert werden. -->
+                        <a href="/geojson/missing/{{ city }}{% if is_cluster %}?is_cluster=true{% endif %}" target="_blank">{{ _('Export missing and not existing') }} (GeoJSON)</a>
                     </li>
                 </ul>
             </div>

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -126,8 +126,8 @@ msgid "Show Clustered"
 msgstr "Gruppiert Anzeigen"
 
 #: app/templates/missing_map.html:114
-msgid "Export Missing"
-msgstr "Fehlende Exportieren"
+msgid "Export missing and not existing"
+msgstr "Fehlende und nicht vorhandene exportieren"
 
 #: app/templates/missing_map.html:120 app/templates/parking_map.html:129
 #: app/templates/rental_map.html:84


### PR DESCRIPTION
Until https://github.com/britiger/bikeparkingberlin/issues/45 is done, this also includes not only missing but also those that are marked non-existing.